### PR TITLE
percent-encode url before asking for interwiki-links

### DIFF
--- a/django/src/routemap/views/routeinfo.py
+++ b/django/src/routemap/views/routeinfo.py
@@ -167,7 +167,7 @@ def wikilink(request, route_id=None, manager=None):
         for k,v in wikientries.iteritems():
             if not v.startswith('http'):
                 try:
-                    url = "http://%s.wikipedia.org/w/api.php?action=query&prop=langlinks&titles=%s&llurl=true&&lllang=%s&format=json" % (k,v,lang)
+                    url = "http://%s.wikipedia.org/w/api.php?action=query&prop=langlinks&titles=%s&llurl=true&&lllang=%s&format=json" % (k,urllib2.quote(v.encode('utf8')),lang)
                     req = urllib2.Request(url, headers={
                         'User-Agent' : 'Python-urllib/2.7 Routemaps (report problems to admin@lonvia.de)'
                         })
@@ -178,7 +178,7 @@ def wikilink(request, route_id=None, manager=None):
                         link = data['langlinks'][0]['url']
                         break
                 except:
-                    break # oh well, we tried
+                    continue # oh well, we tried. Next language, please.
         if link is not None:
             break
 


### PR DESCRIPTION
Spaces and utf8-characters have to be encoded to form a
proper URL.
According to [OSM Wiki. Key:wikipedia](http://wiki.openstreetmap.org/wiki/Key:wikipedia)
the human-readable title should be used in the wikipedia-tag
in favor of an percent-encoded URL.

Examples that were not finding interwiki-articles and are fixed by the attached patch:
[relation 10180](http://hiking.lonvia.de/en/relation/10180), [wikilink](http://hiking.lonvia.de/en/routebrowser/10180/wikilink)
[relation 1732976](http://hiking.lonvia.de/cs/relation/1732976), [wikilink](http://hiking.lonvia.de/cs/routebrowser/1732976/wikilink)
