### PR TITLE
Order sub-relations according to their sequence_id

### DIFF
--- a/django/src/routemap/common/routemodels.py
+++ b/django/src/routemap/common/routemodels.py
@@ -55,7 +55,7 @@ class RouteTableModel(models.Model):
                 self.origname = t['note']        
 
     def subroutes(self, locales=[]):
-        """Returns parent routes of the relation as
+        """Returns child routes of the relation as
            a list of triples (id, name, intnames)
         """
         return self._route_list("""SELECT r.id, r.name, r.intnames FROM routes r, relation_members m
@@ -75,7 +75,7 @@ class RouteTableModel(models.Model):
 
 
     def _route_list(self, query, locales=[]):
-        """Returns parent routes of the relation as a dict with 
+        """Returns parent / child routes of the relation as a dict with 
             the fields 'id', 'name' and, in case the name has been
             localized 'origname' with the original name tag.
         """


### PR DESCRIPTION
Implementation of the simplest solution for issue #65: Join with relation_members.
On my database excerpt this query now takes 0.005sec (was 0.001sec). Please test, if the total runtime is acceptable, otherwise we would have to add a sequence column to hierarchy as you suggested.
