### PR TITLE
Don't list routes covered by header and footer, from WNRI/route.is#56

### DIFF
--- a/static/js/Routes.js
+++ b/static/js/Routes.js
@@ -56,6 +56,16 @@ function setupRouteView(m) {
 var routeviewcounter = 0;
 function loadRoutes() {
     var bounds = map.getExtent();
+    
+    // Make sure relations below header and footer
+    // is not shown in route list
+    var resolution = map.getResolution();
+    topHeader = $('#map_header').height()*resolution;
+    maxY = bounds.top - topHeader;
+    bottomFooter = $('#map_footer').height()*resolution;
+    minY = bounds.bottom + bottomFooter;
+    bounds = new OpenLayers.Bounds(bounds.left, minY, bounds.right, maxY);        
+    
     bounds.transform(map.projection, map.displayProjection);
     var bbox = bounds.toBBOX();
     $("#sb-routes .route-content").addClass("invisible");


### PR DESCRIPTION
This was developed quite a while ago, and thus tested against an earlier point of the branch, but the relevant parts does not seem to have changed and it merged fine.

I do think we should consider also adding an extra margin of some pixels, as it can hardly matter for the user if a route barely touches the boundaries of the map.
