### PR TITLE
_lower and _right were painting full squares with offset ...

### DIFF
--- a/db/common/symbols.py
+++ b/db/common/symbols.py
@@ -725,11 +725,11 @@ class OSMCSymbol(object):
         ctx.stroke()
 
     def paint_fg_lower(self, ctx):
-        ctx.rectangle(0, 0.5, 1, 1)
+        ctx.rectangle(0, 0.5, 1, 0.5)
         ctx.fill()
 
     def paint_fg_right(self, ctx):
-        ctx.rectangle(0.5, 0, 1, 1)
+        ctx.rectangle(0.5, 0, 0.5, 1)
         ctx.fill()
 
     def paint_fg_pointer(self, ctx):


### PR DESCRIPTION
not just the half square that fits into the symbol frame

this isn't a problem with PNG output as this clips to the given
pixel dimensions, but when producing SVGs the 2nd half of the
square that lies outside the symbol frame still shows.