### PR TITLE
make SVG width and height match the viewBox size

### DIFF
--- a/maps/symbols/misc/whitearrow.svg
+++ b/maps/symbols/misc/whitearrow.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg xmlns="http://www.w3.org/2000/svg" height="40" width="16" version="1.1" viewBox="0 0 1 1">
+<svg xmlns="http://www.w3.org/2000/svg" height="1" width="1" version="1.1" viewBox="0 0 1 1">
  <path fill="#ffffff" d="m0.375 0v1l0.3-0.5z"/>
  <path fill="#ffffff00" d="m0.375 0.5h-0.375"/>
 </svg>


### PR DESCRIPTION
SVG handling has changed with Mapnik 3.0.16, leading to wrong sizes
in the slopes overlay which this commit fixes

See also: https://github.com/mapnik/mapnik/issues/3818#issuecomment-355952427

Rendering with Mapnik 3.0.19 before the patch: https://maposmatic.osm-baustelle.de/results//047742_2019-01-28_16-43_.8bit.png

Result with the change applied: https://print.get-map.org/results//047745_2019-01-28_16-56_.8bit.png